### PR TITLE
First pass at LinearRegression

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "danfojs-node": "0.3.0"
   },
   "scripts": {
-    "test": "nyc mocha --require ts-node/register test/**/**/*.test.ts",
+    "test": "nyc mocha --require ts-node/register 'test/**/*.test.ts'",
     "test:clean": "yarn build:clean && yarn test",
     "dev": "nodemon",
     "build": "tsc",

--- a/src/estimators/linear.model.ts
+++ b/src/estimators/linear.model.ts
@@ -1,0 +1,149 @@
+/**
+*  @license
+* Copyright 2021, JsData. All rights reserved.
+*
+* This source code is licensed under the MIT license found in the
+* LICENSE file in the root directory of this source tree.
+
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+* ==========================================================================
+*/
+
+import '@tensorflow/tfjs-node';
+import {
+  Tensor,
+  Tensor1D,
+  Tensor2D,
+  losses,
+  tensor1d,
+  tensor2d,
+  train,
+} from '@tensorflow/tfjs-core';
+import {
+  layers,
+  sequential,
+  Sequential,
+  ModelFitArgs,
+  ModelCompileArgs,
+  callbacks,
+} from '@tensorflow/tfjs-layers';
+import { tensor2dConv, tensor1dConv } from '../utils';
+
+// First pass at a LinearRegression implementation using gradient descent
+// Trying to mimic the API of scikit-learn.org/stable/modules/generated/sklearn.linear_model.LinearRegression.html
+
+export interface LinearRegressionParams {
+  /**
+   * Whether to calculate the intercept for this model. If set to False, no intercept will be used in calculations
+   */
+  fitIntercept?: boolean;
+
+  /**
+   * The complete list of compile args for the `model.compile` call from tensorflow.js.
+   * We aim to provide sensible defaults for LinearRegression.
+   */
+  modelCompileArgs: ModelCompileArgs;
+
+  /**
+   * The complete list of `model.fit` args from Tensorflow.js
+   * We aim to provide sensible defaults for LinearRegression.
+   */
+  modelFitArgs: ModelFitArgs;
+}
+
+export default class LinearRegression {
+  model: Sequential;
+  modelFitArgs: ModelFitArgs;
+  modelCompileArgs: ModelCompileArgs;
+  fitIntercept: boolean;
+
+  constructor(
+    params: LinearRegressionParams = {
+      fitIntercept: true,
+      modelCompileArgs: {
+        optimizer: train.adam(0.1),
+        loss: losses.meanSquaredError,
+        metrics: ['mse'],
+      },
+      modelFitArgs: {
+        batchSize: 32,
+        epochs: 1000,
+        verbose: 0,
+        callbacks: [callbacks.earlyStopping({ monitor: 'mse', patience: 50 })],
+      },
+    }
+  ) {
+    this.model = sequential();
+    this.fitIntercept = Boolean(params.fitIntercept);
+    this.modelFitArgs = params.modelFitArgs;
+    this.modelCompileArgs = params.modelCompileArgs;
+  }
+
+  initializeModel(
+    inputShape: number,
+    useBias = true,
+    weightsTensors: Tensor[] = []
+  ): void {
+    const model = sequential();
+    model.add(layers.dense({ inputShape: [inputShape], units: 1, useBias }));
+    model.compile(this.modelCompileArgs);
+    if (weightsTensors?.length) {
+      model.setWeights(weightsTensors);
+    }
+    this.model = model;
+  }
+
+  async fit(X: Tensor2D | number[][], y: Tensor1D | number[]) {
+    let XTwoD = tensor2dConv(X);
+    let yOneD = tensor1dConv(y);
+    if (this.model.layers.length === 0) {
+      this.initializeModel(XTwoD.shape[1], this.fitIntercept);
+    }
+    await this.model.fit(XTwoD, yOneD, { ...this.modelFitArgs });
+  }
+
+  importModel(params: {
+    coef_: number[];
+    intercept_: number;
+  }): LinearRegression {
+    let myCoef = tensor2d(params.coef_, [params.coef_.length, 1], 'float32');
+    let myIntercept = tensor1d([params.intercept_], 'float32');
+    this.initializeModel(params.coef_.length, true, [myCoef, myIntercept]);
+    return this;
+  }
+
+  getParams(): LinearRegressionParams {
+    return {
+      fitIntercept: this.fitIntercept,
+      modelFitArgs: this.modelFitArgs,
+      modelCompileArgs: this.modelCompileArgs,
+    };
+  }
+
+  setParams(params: LinearRegressionParams): LinearRegression {
+    this.fitIntercept = Boolean(params.fitIntercept);
+    this.modelCompileArgs = params.modelCompileArgs;
+    this.modelFitArgs = params.modelFitArgs;
+    return this;
+  }
+
+  predict(X: Tensor2D | number[][]): Tensor2D {
+    let XTwoD = tensor2dConv(X);
+    if (this.model.layers.length === 0) {
+      throw new RangeError('Need to call "fit" before "predict"');
+    }
+    return this.model.predict(XTwoD) as Tensor2D;
+  }
+
+  get coef_(): Tensor {
+    return this.model.getWeights()[0];
+  }
+
+  get intercept_(): Tensor {
+    return this.model.getWeights()[1];
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,17 +13,19 @@
 * ==========================================================================
 */
 
-import MinMaxScaler from "./preprocessing/scalers/min.max.scaler"
-import StandardScaler from "./preprocessing/scalers/standard.scaler"
+import LinearRegression from './estimators/linear.model';
+import MinMaxScaler from './preprocessing/scalers/min.max.scaler';
+import StandardScaler from './preprocessing/scalers/standard.scaler';
 
-import getDummies from "./preprocessing/encoders/dummy.encoder"
-import OneHotEncoder from "./preprocessing/encoders/one.hot.encoder"
-import LabelEncoder from "./preprocessing/encoders/label.encoder"
+import getDummies from './preprocessing/encoders/dummy.encoder';
+import OneHotEncoder from './preprocessing/encoders/one.hot.encoder';
+import LabelEncoder from './preprocessing/encoders/label.encoder';
 
 export {
-    MinMaxScaler,
-    StandardScaler,
-    getDummies,
-    OneHotEncoder,
-    LabelEncoder
-}
+  MinMaxScaler,
+  StandardScaler,
+  getDummies,
+  OneHotEncoder,
+  LabelEncoder,
+  LinearRegression,
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,38 +12,73 @@
 * limitations under the License.
 * ==========================================================================
 */
-import { ArrayType1D, ArrayType2D } from "types";
-
+import { ArrayType1D, ArrayType2D } from 'types';
+import {
+  Tensor1D,
+  Tensor2D,
+  Tensor,
+  tensor1d,
+  tensor2d,
+} from '@tensorflow/tfjs-core';
+import { TypedArray } from '@tensorflow/tfjs-node';
 /**
-* Generates an array of dim (row x column) with inner values set to zero
-* @param row 
-* @param column 
-*/
-export const zeros = (row: number, column: number): ArrayType1D | ArrayType2D => {
-    const zeroData = [];
-    for (let i = 0; i < row; i++) {
-        const colData = Array(column);
-        for (let j = 0; j < column; j++) {
-            colData[j] = 0;
-        }
-        zeroData.push(colData);
+ * Generates an array of dim (row x column) with inner values set to zero
+ * @param row
+ * @param column
+ */
+export const zeros = (
+  row: number,
+  column: number
+): ArrayType1D | ArrayType2D => {
+  const zeroData = [];
+  for (let i = 0; i < row; i++) {
+    const colData = Array(column);
+    for (let j = 0; j < column; j++) {
+      colData[j] = 0;
     }
-    return zeroData;
-}
-
+    zeroData.push(colData);
+  }
+  return zeroData;
+};
 
 /**
  * Checks if array is 1D
- * @param arr The array 
-*/
+ * @param arr The array
+ */
 export const is1DArray = (arr: ArrayType1D | ArrayType2D): boolean => {
-    if (
-        typeof arr[0] == "number" ||
-        typeof arr[0] == "string" ||
-        typeof arr[0] == "boolean"
-    ) {
-        return true;
+  if (
+    typeof arr[0] == 'number' ||
+    typeof arr[0] == 'string' ||
+    typeof arr[0] == 'boolean'
+  ) {
+    return true;
+  } else {
+    return false;
+  }
+};
+
+export function tensor2dConv(X: Tensor | number[][]): Tensor2D {
+  if (X instanceof Tensor) {
+    const dim = X.rank;
+    if (dim === 2) {
+      return X as Tensor2D;
     } else {
-        return false;
+      throw new RangeError('Tensor is not 2D');
     }
+  } else {
+    return tensor2d(X);
+  }
+}
+
+export function tensor1dConv(X: Tensor | number[] | TypedArray): Tensor1D {
+  if (X instanceof Tensor) {
+    const dim = X.rank;
+    if (dim === 1) {
+      return X as Tensor1D;
+    } else {
+      throw new RangeError('Tensor is not 1D');
+    }
+  } else {
+    return tensor1d(X);
+  }
 }

--- a/test/estimators/linear.model.test.ts
+++ b/test/estimators/linear.model.test.ts
@@ -1,0 +1,16 @@
+import '@tensorflow/tfjs-backend-cpu';
+import * as tf from '@tensorflow/tfjs-core';
+import { assert } from 'chai';
+import { LinearRegression } from '../../dist';
+import 'mocha';
+import { tensorEqual } from '../utils.test';
+
+describe('LinearRegression', function () {
+  this.timeout(10000);
+  it('Works on arrays (small example)', async function () {
+    const lr = new LinearRegression();
+    await lr.fit([[1], [2]], [2, 4]);
+    assert.isTrue(tensorEqual(lr.coef_, tf.tensor2d([[2]]), 0.01));
+    assert.isTrue(tensorEqual(lr.intercept_, tf.tensor1d([0]), 0.01));
+  });
+});

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,0 +1,43 @@
+import * as tf from '@tensorflow/tfjs-node';
+
+/**
+ * Check that if two tensor are of same shape
+ * @param tensor1
+ * @param tensor2
+ * @returns
+ */
+export const shapeEqual = (
+  tensor1: tf.Tensor,
+  tensor2: tf.Tensor
+): boolean => {
+  const shape1 = tensor1.shape;
+  const shape2 = tensor2.shape;
+  if (shape1.length != shape2.length) {
+    return false;
+  }
+  for (let i = 0; i < shape1.length; i++) {
+    if (shape1[i] !== shape2[i]) {
+      return false;
+    }
+  }
+  return true;
+};
+
+/**
+ * Check that two tensors are equal to within some additive tolerance.
+ * @param tensor1
+ * @param tensor2
+ * @param
+ */
+export const tensorEqual = (
+  tensor1: tf.Tensor,
+  tensor2: tf.Tensor,
+  tol = 0
+): boolean => {
+  if (!shapeEqual(tensor1, tensor2)) {
+    throw new Error('tensor1 and tensor2 not of same shape');
+  }
+  return Boolean(
+    tf.lessEqual(tf.max(tf.abs(tf.sub(tensor1, tensor2))), tol).dataSync()[0]
+  );
+};


### PR DESCRIPTION
Here's a first pass at LinearRegression in scikit.js.

First some notes on how I'm approaching this.

### 1. Obviously we are keeping the signature as close to scikit-learn as possible.

I've done all of the methods except for "score". I've also added a function called "importModel" 
which does the "importing from python" that we talked about in the discussion here.

The LinearRegression in Scikit-Learn doesn't use gradient descent (like this one). It uses some 
production level linalg solvers. Eventually in the long run, we should do the same thing. This is a holdover
until we get some better / faster code in here. 

### 2. I think it's probable wise to use get/set methods to match the Scikit-Learn Api

For LinearRegression in sklearn, you can just go **lr.coef_** and **lr.intercept_** to get those values.
We store the internal model as tf.sequential, so it makes sense to basically use getters/setters to not
break the contract.

### 3. I'm not sure what our plan is with prettier.js? 
 
Currently I'm operating off of the .prettier file in the repo, but some of the code in the repo is ignoring that. Moreover, my personal preference is indentation is 2, and no semi-colons. Though, I don't really care that much. I more just wanna make sure we are all on the same page, and that it runs semi-automatically in the repo.

### 4. I've never used JSDoc before but it seems great. 

I'm gonna add it in my next pass. Just wanted to get this PR in before I go to bed. I also plan on adding a lot more tests.

### 5. I drunkenly asked my buddy to make a logo for scikit.js. 
I've attached it. If ya like it, we can start there. Otherwise, we can make something else.

<img width="596" alt="Screen Shot 2021-09-29 at 10 25 51 PM" src="https://user-images.githubusercontent.com/470683/135392530-81ed4901-10fc-4d74-9fec-da8c968573f5.png">

I've attached a png screenshot only because Github complains when I try to put in an svg :)